### PR TITLE
offscreen canvas, needed for web worker

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -99,10 +99,13 @@ class Model {
     util.forAll(contexts, (val, key) => {
       if (val === null) return
       const ctx = util.createCtx(1, 1, val.ctx)
-      Object.assign(ctx.canvas.style, {
-        position: 'absolute', top: 0, left: 0, zIndex: val.z
-      })
-      this.div.appendChild(ctx.canvas)
+      const canvas = ctx.canvas || ctx.offscreenCanvas
+      if (canvas.style) {
+        Object.assign(canvas.style, {
+          position: 'absolute', top: 0, left: 0, zIndex: val.z
+        })
+        this.div.appendChild(canvas)
+      }
       contexts[key] = ctx
     })
     this.contexts = contexts
@@ -113,8 +116,9 @@ class Model {
     const { pxWidth: width, pxHeight: height } = this.world
     util.forAll(this.contexts, (ctx, key) => {
       if (ctx === null) return
-      Object.assign(ctx.canvas, { width, height })
-      Object.assign(ctx.canvas.style, { width, height })
+      const canvas = ctx.canvas || ctx.offscreenCanvas
+      Object.assign(canvas, { width, height })
+      if (canvas.style) Object.assign(canvas.style, { width, height })
       this.setFont(key)
       this.setCtxTransform(ctx)
       if (key === 'patches') util.setCtxSmoothing(ctx, false)

--- a/src/Patches.js
+++ b/src/Patches.js
@@ -103,7 +103,8 @@ class Patches extends AgentSet {
     const {pixels} = this
     pixels.ctx.putImageData(pixels.imageData, 0, 0)
     if (pixels.are1x1) return
-    util.fillCtxWithImage(ctx, pixels.ctx.canvas)
+    const canvas = pixels.ctx.canvas || pixels.ctx.offscreenCanvas
+    util.fillCtxWithImage(ctx, canvas)
     for (const i in this.labels) { // `for .. in`: skips sparse array gaps.
       const label = this.labels[i]
       const {labelOffset: offset, labelColor: color} = this[i]

--- a/src/util.js
+++ b/src/util.js
@@ -516,7 +516,7 @@ const util = {
   // As above, but returing the context object.
   // NOTE: ctx.canvas is the canvas for the ctx, and can be use as an image.
   createCtx (width, height, ctxType = '2d') {
-    const can = this.createCanvas(width, height) // this.createCanvas(width, height)
+    const can = this.createCanvas(width, height)
     return can.getContext(ctxType === '2d' ? '2d' : 'webgl')
   },
   // Return the (complete) ImageData object for this context object


### PR DESCRIPTION
- The option to use offscreen canvas.
  - this is needed for web workers to use models, since they dont have a dom. 
